### PR TITLE
Add license info to the gemspec.

### DIFF
--- a/cldr-plurals-runtime-rb.gemspec
+++ b/cldr-plurals-runtime-rb.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.authors  = ["Cameron Dutro"]
   s.email    = ["camertron@gmail.com"]
   s.homepage = "http://github.com/camertron"
+  s.license  = "MIT"
 
   s.description = s.summary = 'Ruby runtime methods for CLDR plural rules (see camertron/cldr-plurals).'
 


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.